### PR TITLE
Enable doc tests for simple functions

### DIFF
--- a/llvm/arr_value.mbt
+++ b/llvm/arr_value.mbt
@@ -76,7 +76,7 @@ pub fn ArrayValue::replace_all_uses_with(
 ///
 /// ## Example
 ///
-/// ```moonbit skip
+/// ```moonbit
 /// let context = Context::create();
 /// let i64_type = context.i64_type();
 /// let i64_val = i64_type.const_int(23);

--- a/llvm/context.mbt
+++ b/llvm/context.mbt
@@ -102,7 +102,7 @@ pub fn Context::i8_type(self : Context) -> IntType {
 ///
 /// ## Example
 ///
-/// ```moonbit skip
+/// ```moonbit
 /// let context = Context::create()
 /// let i16_ty = context.i16_type()
 /// inspect(i16_ty, content="i16")
@@ -116,7 +116,7 @@ pub fn Context::i16_type(self : Context) -> IntType {
 ///
 /// ## Example
 ///
-/// ```moonbit skip
+/// ```moonbit
 /// let context = Context::create()
 /// let i32_ty = context.i32_type()
 /// inspect(i32_ty, content="i32")
@@ -130,7 +130,7 @@ pub fn Context::i32_type(self : Context) -> IntType {
 ///
 /// ## Example
 ///
-/// ```moonbit skip
+/// ```moonbit
 /// let context = Context::create()
 /// let i64_ty = context.i64_type()
 /// inspect(i64_ty, content="i64")


### PR DESCRIPTION
## Summary
- unskip an example in `ArrayValue::is_const`
- unskip examples for creating i16/i32/i64 types

## Testing
- `moon test --target native`
- `moon check --target native`


------
https://chatgpt.com/codex/tasks/task_e_685a73b2f6a88331b3d8d6dc2487d5fc