### PR TITLE
[codex] fix warning 0027 deprecated syntax

### DIFF
--- a/IR/BasicBlock.mbt
+++ b/IR/BasicBlock.mbt
@@ -89,7 +89,7 @@ pub fn BasicBlock::getNextBasicBlock(self : Self) -> BasicBlock? {
 ///|
 pub suberror BasicBlockHasNoParentError {
   BasicBlockHasNoParentError(String)
-} derive(Show)
+} derive(Debug)
 
 // REVIEW: Should we check basic block must have parent?
 

--- a/IR/Errors.mbt
+++ b/IR/Errors.mbt
@@ -1,4 +1,4 @@
 ///|
 pub suberror IndexOutOfBounds {
   IndexOutOfBounds(String)
-} derive(Show)
+} derive(Debug)

--- a/IR/IRBuilder.mbt
+++ b/IR/IRBuilder.mbt
@@ -6,7 +6,7 @@
 enum PositionState {
   NotSet
   Set
-} derive(Show, Eq)
+} derive(Debug, Eq)
 
 ///|
 pub suberror BuilderError {
@@ -16,7 +16,7 @@ pub suberror BuilderError {
   BitwidthError(String)
   InValidArgument(String)
   UnImplemented(String)
-} derive(Show)
+} derive(Debug)
 
 ///|
 trait InsertPoint {

--- a/IR/Instruction.mbt
+++ b/IR/Instruction.mbt
@@ -678,7 +678,7 @@ pub fn BranchInst::isConditional(self : BranchInst) -> Bool {
 ///|
 pub suberror InValidOperation {
   InValidOperation(String)
-} derive(Show)
+} derive(Debug)
 
 ///|
 #callsite(autofill(loc))
@@ -840,7 +840,7 @@ pub(all) enum TailCallKind {
   Tail
   MustTail
   NoTail
-} derive(Show)
+} derive(Debug)
 
 ///|
 fn TailCallKind::to_llvm(self : TailCallKind) -> @unsafe.LLVMTailCallKind {

--- a/IR/Interpreter.mbt
+++ b/IR/Interpreter.mbt
@@ -7,7 +7,7 @@ pub struct GenericValue(@unsafe.LLVMGenericValueRef)
 ///|
 pub suberror InterpreterError {
   CreateInterpreterFailed(String)
-} derive(Show)
+} derive(Debug)
 
 ///|
 pub struct Interpreter {

--- a/IR/Module.mbt
+++ b/IR/Module.mbt
@@ -44,13 +44,14 @@ pub fn Module::getFunction(self : Self, name : String) -> Function? {
 ///|
 pub fn Module::getFunctions(self : Self) -> Array[Function] {
   let funcs : Array[Function] = Array::new()
-  let func = self.getFirstFunction()
-  loop func {
-    Some(f) => {
-      funcs.push(f)
-      continue f.getNextFunction()
+  for func = self.getFirstFunction() {
+    match func {
+      Some(f) => {
+        funcs.push(f)
+        continue f.getNextFunction()
+      }
+      None => break funcs
     }
-    None => break funcs
   }
 }
 
@@ -181,7 +182,7 @@ pub fn Module::addGlobalConstant(
 ///|
 pub suberror WriteBitCodeToFileFailed {
   WriteBitCodeToFileFailed(String)
-} derive(Show)
+} derive(Debug)
 
 ///|
 pub fn Module::writeBitCodeToFile(

--- a/IR/Type.mbt
+++ b/IR/Type.mbt
@@ -20,7 +20,7 @@ pub enum TypeEnum {
   VectorType(VectorType)
   ScalableVectorType(ScalableVectorType)
   PointerType(PointerType)
-} derive(Eq, Show)
+} derive(Eq)
 
 ///|
 pub fn TypeEnum::asTypeClass(self : TypeEnum) -> &Type {
@@ -140,9 +140,19 @@ pub trait Type: Show {
 }
 
 ///|
+fn type_debug_repr(ty : &Type) -> @debug.Repr {
+  @debug.Repr::literal(ty.to_string())
+}
+
+///|
+pub impl Debug for TypeEnum with fn to_repr(self) {
+  type_debug_repr(self.asTypeClass())
+}
+
+///|
 pub suberror InValidTypeError {
   InValidTypeError(String)
-} derive(Show)
+} derive(Debug)
 
 ///|
 fn initAbstractType_err(
@@ -511,7 +521,7 @@ pub enum IntegerTypeEnum {
   Int16Type(Int16Type)
   Int32Type(Int32Type)
   Int64Type(Int64Type)
-} derive(Eq, Show)
+} derive(Eq)
 
 ///|
 pub fn IntegerTypeEnum::asTypeClass(self : IntegerTypeEnum) -> &Type {
@@ -522,6 +532,11 @@ pub fn IntegerTypeEnum::asTypeClass(self : IntegerTypeEnum) -> &Type {
     Int32Type(t) => t
     Int64Type(t) => t
   }
+}
+
+///|
+pub impl Debug for IntegerTypeEnum with fn to_repr(self) {
+  type_debug_repr(self.asTypeClass())
 }
 
 ///|
@@ -554,7 +569,7 @@ pub enum FPTypeEnum {
   FloatType(FloatType)
   DoubleType(DoubleType)
   FP128Type(FP128Type)
-} derive(Eq, Show)
+} derive(Eq)
 
 ///|
 pub fn FPTypeEnum::asTypeClass(self : FPTypeEnum) -> &Type {
@@ -565,6 +580,11 @@ pub fn FPTypeEnum::asTypeClass(self : FPTypeEnum) -> &Type {
     DoubleType(t) => t
     FP128Type(t) => t
   }
+}
+
+///|
+pub impl Debug for FPTypeEnum with fn to_repr(self) {
+  type_debug_repr(self.asTypeClass())
 }
 
 ///|
@@ -626,7 +646,24 @@ pub enum PrimitiveTypeEnum {
   Int16Type(Int16Type)
   Int32Type(Int32Type)
   Int64Type(Int64Type)
-} derive(Eq, Show)
+} derive(Eq)
+
+///|
+pub impl Debug for PrimitiveTypeEnum with fn to_repr(self) {
+  let ty : &Type = match self {
+    HalfType(t) => (t : &Type)
+    BFloatType(t) => t
+    FloatType(t) => t
+    DoubleType(t) => t
+    FP128Type(t) => t
+    Int1Type(t) => t
+    Int8Type(t) => t
+    Int16Type(t) => t
+    Int32Type(t) => t
+    Int64Type(t) => t
+  }
+  type_debug_repr(ty)
+}
 
 // ====================================================================
 // Aggregate Types, AggregateType && AggregateTypeEnum
@@ -654,7 +691,7 @@ pub enum AggregateTypeEnum {
   ArrayType(ArrayType)
   VectorType(VectorType)
   ScalableVectorType(ScalableVectorType)
-} derive(Eq, Show)
+} derive(Eq)
 
 ///|
 pub fn AggregateTypeEnum::toTypeEnum(self : AggregateTypeEnum) -> TypeEnum {
@@ -676,6 +713,11 @@ pub fn AggregateTypeEnum::asTypeClass(self : Self) -> &Type {
   }
 }
 
+///|
+pub impl Debug for AggregateTypeEnum with fn to_repr(self) {
+  type_debug_repr(self.asTypeClass())
+}
+
 // ====================================================================
 // Abstract Types, AbstractType && AbstractTypeEnum
 // ====================================================================
@@ -692,7 +734,19 @@ pub enum AbstractTypeEnum {
   MetadataType(MetadataType)
   TokenType(TokenType)
   FunctionType(FunctionType)
-} derive(Show)
+}
+
+///|
+pub impl Debug for AbstractTypeEnum with fn to_repr(self) {
+  let ty : &Type = match self {
+    VoidType(t) => (t : &Type)
+    LabelType(t) => t
+    MetadataType(t) => t
+    TokenType(t) => t
+    FunctionType(t) => t
+  }
+  type_debug_repr(ty)
+}
 
 // ====================================================================
 // HalfType
@@ -1329,7 +1383,7 @@ pub fn StructType::elements(self : StructType) -> Array[&Type] {
 ///|
 pub suberror SetBodyForNonOpaqueStruct {
   SetBodyForNonOpaqueStruct(String)
-} derive(Show)
+} derive(Debug)
 
 ///|
 /// Set the body of the struct.
@@ -1494,7 +1548,7 @@ pub impl AggregateType for ScalableVectorType with fn asAggregateTypeEnum(self) 
 
 ///|
 /// Memory address space of a pointer type.
-pub struct AddressSpace(UInt) derive(Hash, Show, Eq, Default)
+pub struct AddressSpace(UInt) derive(Hash, Debug, Eq, Default)
 
 ///|
 pub fn AddressSpace::new(v : UInt) -> AddressSpace {

--- a/IR/moon.pkg
+++ b/IR/moon.pkg
@@ -1,6 +1,7 @@
 supported_targets = "native"
 
 import {
+  "moonbitlang/core/debug",
   "Kaida-Amethyst/llvm/unsafe",
   "moonbitlang/core/uint",
 }

--- a/IR/pkg.generated.mbti
+++ b/IR/pkg.generated.mbti
@@ -3,6 +3,7 @@ package "Kaida-Amethyst/llvm/IR"
 
 import {
   "Kaida-Amethyst/llvm/unsafe",
+  "moonbitlang/core/debug",
 }
 
 // Values
@@ -10,7 +11,7 @@ import {
 // Errors
 pub suberror BasicBlockHasNoParentError {
   BasicBlockHasNoParentError(String)
-} derive(Show)
+} derive(@debug.Debug)
 
 pub suberror BuilderError {
   UnsetPosition
@@ -19,27 +20,27 @@ pub suberror BuilderError {
   BitwidthError(String)
   InValidArgument(String)
   UnImplemented(String)
-} derive(Show)
+} derive(@debug.Debug)
 
 pub suberror InValidOperation {
   InValidOperation(String)
-} derive(Show)
+} derive(@debug.Debug)
 
 pub suberror InValidTypeError {
   InValidTypeError(String)
-} derive(Show)
+} derive(@debug.Debug)
 
 pub suberror IndexOutOfBounds {
   IndexOutOfBounds(String)
-} derive(Show)
+} derive(@debug.Debug)
 
 pub suberror InterpreterError {
   CreateInterpreterFailed(String)
-} derive(Show)
+} derive(@debug.Debug)
 
 pub suberror SetBodyForNonOpaqueStruct {
   SetBodyForNonOpaqueStruct(String)
-} derive(Show)
+} derive(@debug.Debug)
 
 pub suberror SwitchInstError {
   InValidSwitchCaseValue(String)
@@ -47,7 +48,7 @@ pub suberror SwitchInstError {
 
 pub suberror WriteBitCodeToFileFailed {
   WriteBitCodeToFileFailed(String)
-} derive(Show)
+} derive(@debug.Debug)
 
 // Types and methods
 pub enum AbstractTypeEnum {
@@ -56,9 +57,10 @@ pub enum AbstractTypeEnum {
   MetadataType(MetadataType)
   TokenType(TokenType)
   FunctionType(FunctionType)
-} derive(Show)
+}
+pub impl @debug.Debug for AbstractTypeEnum
 
-pub struct AddressSpace(UInt) derive(Default, Eq, Hash, Show)
+pub struct AddressSpace(UInt) derive(Default, Eq, Hash, @debug.Debug)
 pub fn AddressSpace::new(UInt) -> Self
 
 pub enum AggregateTypeEnum {
@@ -66,9 +68,10 @@ pub enum AggregateTypeEnum {
   ArrayType(ArrayType)
   VectorType(VectorType)
   ScalableVectorType(ScalableVectorType)
-} derive(Eq, Show)
+} derive(Eq)
 pub fn AggregateTypeEnum::asTypeClass(Self) -> &Type
 pub fn AggregateTypeEnum::toTypeEnum(Self) -> TypeEnum
+pub impl @debug.Debug for AggregateTypeEnum
 
 pub struct AllocaInst(@unsafe.LLVMValueRef)
 pub fn AllocaInst::getAllocatedType(Self) -> &Type
@@ -287,9 +290,10 @@ pub enum FPTypeEnum {
   FloatType(FloatType)
   DoubleType(DoubleType)
   FP128Type(FP128Type)
-} derive(Eq, Show)
+} derive(Eq)
 pub fn FPTypeEnum::asTypeClass(Self) -> &Type
 pub fn FPTypeEnum::getFPMantissaWidth(Self) -> UInt
+pub impl @debug.Debug for FPTypeEnum
 
 pub(all) enum FastMathFlags {
   AllowReassoc
@@ -665,9 +669,10 @@ pub enum IntegerTypeEnum {
   Int16Type(Int16Type)
   Int32Type(Int32Type)
   Int64Type(Int64Type)
-} derive(Eq, Show)
+} derive(Eq)
 pub fn IntegerTypeEnum::asTypeClass(Self) -> &Type
 pub fn IntegerTypeEnum::getBitWidth(Self) -> UInt
+pub impl @debug.Debug for IntegerTypeEnum
 
 pub struct Interpreter {
   engine : @unsafe.LLVMExecutionEngineRef
@@ -767,7 +772,7 @@ pub impl Constant for PoisonValue
 pub impl Value for PoisonValue
 pub impl Show for PoisonValue
 
-type PositionState derive(Eq, Show)
+type PositionState derive(Eq, @debug.Debug)
 
 pub enum PrimitiveTypeEnum {
   HalfType(HalfType)
@@ -780,7 +785,8 @@ pub enum PrimitiveTypeEnum {
   Int16Type(Int16Type)
   Int32Type(Int32Type)
   Int64Type(Int64Type)
-} derive(Eq, Show)
+} derive(Eq)
+pub impl @debug.Debug for PrimitiveTypeEnum
 
 pub(all) enum RetAttr {
   NoAlias
@@ -842,7 +848,7 @@ pub(all) enum TailCallKind {
   Tail
   MustTail
   NoTail
-} derive(Show)
+} derive(@debug.Debug)
 
 pub struct TokenType(@unsafe.LLVMTypeRef) derive(Eq)
 pub impl AbstractType for TokenType
@@ -870,8 +876,9 @@ pub enum TypeEnum {
   VectorType(VectorType)
   ScalableVectorType(ScalableVectorType)
   PointerType(PointerType)
-} derive(Eq, Show)
+} derive(Eq)
 pub fn TypeEnum::asTypeClass(Self) -> &Type
+pub impl @debug.Debug for TypeEnum
 
 pub struct UnaryInst(@unsafe.LLVMValueRef)
 pub impl InsertPoint for UnaryInst

--- a/unsafe/Types.mbt
+++ b/unsafe/Types.mbt
@@ -206,16 +206,16 @@ pub type LLVMErrorRef
 
 ///|
 /// Represents an address in the executor process.
-pub(all) struct LLVMOrcJITTargetAddress(UInt64) derive(Show, Eq)
+pub(all) struct LLVMOrcJITTargetAddress(UInt64) derive(Debug, Eq)
 
 ///|
 /// Represents an address in the executor process.
-pub(all) struct LLVMOrcExecutorAddress(UInt64) derive(Show, Eq, Default)
+pub(all) struct LLVMOrcExecutorAddress(UInt64) derive(Debug, Eq, Default)
 
 // NOTE: It different with real, the real LLVMJITSymbolTargetFlags is uint8
 
 ///|
-pub(all) struct LLVMJITSymbolTargetFlags(UInt) derive(Show, Eq)
+pub(all) struct LLVMJITSymbolTargetFlags(UInt) derive(Debug, Eq)
 
 ///|
 /// A reference to an orc::ExecutionSession instance.
@@ -356,7 +356,12 @@ pub(all) enum LLVMOpcode {
   LLVMCatchPad
   LLVMCleanupPad
   LLVMCatchSwitch
-} derive(Show)
+} derive(Debug)
+
+///|
+pub impl Show for LLVMOpcode with fn output(self, logger) {
+  logger.write_string(@debug.to_string(self))
+}
 
 ///|
 pub fn LLVMOpcode::to_int(self : LLVMOpcode) -> Int {
@@ -528,7 +533,12 @@ pub(all) enum LLVMTypeKind {
   LLVMBFloatTypeKind
   LLVMX86_AMXTypeKind
   LLVMTargetExtTypeKind
-} derive(Show, Eq)
+} derive(Debug, Eq)
+
+///|
+pub impl Show for LLVMTypeKind with fn output(self, logger) {
+  logger.write_string(@debug.to_string(self))
+}
 
 ///|
 pub fn LLVMTypeKind::to_int(self : LLVMTypeKind) -> Int {
@@ -684,7 +694,7 @@ pub(all) enum LLVMUnnamedAddr {
   LLVMNoUnnamedAddr
   LLVMLocalUnnamedAddr
   LLVMGlobalUnnamedAddr
-} derive(Show, Eq)
+} derive(Debug, Eq)
 
 ///|
 pub fn LLVMUnnamedAddr::to_int(self : LLVMUnnamedAddr) -> Int {

--- a/unsafe/moon.pkg
+++ b/unsafe/moon.pkg
@@ -1,5 +1,9 @@
 supported_targets = "native"
 
+import {
+  "moonbitlang/core/debug",
+}
+
 options(
   "is-main": false,
   "native-stub": [ "wrap.c" ],

--- a/unsafe/pkg.generated.mbti
+++ b/unsafe/pkg.generated.mbti
@@ -1,6 +1,10 @@
 // Generated using `moon info`, DON'T EDIT IT
 package "Kaida-Amethyst/llvm/unsafe"
 
+import {
+  "moonbitlang/core/debug",
+}
+
 // Values
 pub fn llvm_abi_alignment_of_type(LLVMTargetDataRef, LLVMTypeRef) -> UInt
 
@@ -2272,7 +2276,7 @@ pub(all) enum LLVMJITSymbolGenericFlags {
 pub fn LLVMJITSymbolGenericFlags::from_int(Int) -> Self
 pub fn LLVMJITSymbolGenericFlags::to_int(Self) -> Int
 
-pub(all) struct LLVMJITSymbolTargetFlags(UInt) derive(Eq, Show)
+pub(all) struct LLVMJITSymbolTargetFlags(UInt) derive(Eq, @debug.Debug)
 
 pub(all) enum LLVMLandingPadClauseTy {
   LLVMLandingPadCatch
@@ -2483,9 +2487,10 @@ pub(all) enum LLVMOpcode {
   LLVMCatchPad
   LLVMCleanupPad
   LLVMCatchSwitch
-} derive(Show)
+} derive(@debug.Debug)
 pub fn LLVMOpcode::from_int(Int) -> Self
 pub fn LLVMOpcode::to_int(Self) -> Int
+pub impl Show for LLVMOpcode
 
 #external
 pub type LLVMOperandBundleRef
@@ -2496,12 +2501,12 @@ pub fn LLVMOperandBundleRef::get_num_args(Self) -> UInt
 #external
 pub type LLVMOrcExecutionSessionRef
 
-pub(all) struct LLVMOrcExecutorAddress(UInt64) derive(Default, Eq, Show)
+pub(all) struct LLVMOrcExecutorAddress(UInt64) derive(Default, Eq, @debug.Debug)
 
 #external
 pub type LLVMOrcJITDylibRef
 
-pub(all) struct LLVMOrcJITTargetAddress(UInt64) derive(Eq, Show)
+pub(all) struct LLVMOrcJITTargetAddress(UInt64) derive(Eq, @debug.Debug)
 
 #external
 pub type LLVMOrcLLJITBuilderRef
@@ -2640,9 +2645,10 @@ pub(all) enum LLVMTypeKind {
   LLVMBFloatTypeKind
   LLVMX86_AMXTypeKind
   LLVMTargetExtTypeKind
-} derive(Eq, Show)
+} derive(Eq, @debug.Debug)
 pub fn LLVMTypeKind::from_int(Int) -> Self
 pub fn LLVMTypeKind::to_int(Self) -> Int
+pub impl Show for LLVMTypeKind
 
 #external
 pub type LLVMTypeRef
@@ -2724,7 +2730,7 @@ pub(all) enum LLVMUnnamedAddr {
   LLVMNoUnnamedAddr
   LLVMLocalUnnamedAddr
   LLVMGlobalUnnamedAddr
-} derive(Eq, Show)
+} derive(Eq, @debug.Debug)
 pub fn LLVMUnnamedAddr::from_int(Int) -> Self
 pub fn LLVMUnnamedAddr::to_int(Self) -> Int
 


### PR DESCRIPTION
## Summary

- Replace deprecated `derive(Show)` syntax with `derive(Debug)` or manual `Debug` for warning 0027 sites.
- Rewrite the legacy functional `loop` in `Module::getFunctions` to an explicit `for` loop.
- Keep `Show` only where there is a real display contract: concrete IR `Type` implementations already render canonical LLVM type text via `Type: Show`, and `LLVMOpcode`/`LLVMTypeKind` are still used in existing string interpolation. Other unsafe wrappers/enums are Debug-only.

## Validation

- `moon check --target native --diagnostic-limit 10000` passes; no warning 0027 remains. Remaining warnings are warning 0020 only and are handled separately.
- `moon info --target native`
- `moon fmt`
- `git diff --check`

## Test note

- `moon test --target native` is blocked in this checkout before running tests by the local LLVM/native-stub setup. Without forced include paths, clang cannot find `llvm-c/Analysis.h`; forcing the available LLVM 18 headers moves compilation forward but fails on LLVM 19-only enum values, and LLVM 19 is not installed locally.
