### PR TITLE
[codex] fix warning 0020 deprecated APIs

### DIFF
--- a/IR/Context.mbt
+++ b/IR/Context.mbt
@@ -305,7 +305,7 @@ pub fn Context::getStructType(
   isPacked? : Bool = false,
   name? : String = "",
 ) -> StructType {
-  guard not(name.is_empty() && elements.is_empty()) else {
+  guard !(name.is_empty() && elements.is_empty()) else {
     println(
       "Error: Misuse `Context::getStructType`:  Empty struct type must have a name.",
     )

--- a/IR/Function.mbt
+++ b/IR/Function.mbt
@@ -267,7 +267,7 @@ pub fn Function::addFnAttr(self : Self, attr : FnAttr) -> Unit {
   let fn_attr = attr.to_llvm_attr(self.getContext())
   @unsafe.llvm_add_attribute_at_index(
     self.getValueRef(),
-    @uint.max_value,
+    @uint.MAX_VALUE,
     fn_attr.0,
   )
 }
@@ -322,7 +322,7 @@ pub fn Function::removeFnAttr(self : Self, fn_attr : FnAttr) -> Unit {
   )
   @unsafe.llvm_remove_enum_attribute_at_index(
     self.getValueRef(),
-    @uint.max_value,
+    @uint.MAX_VALUE,
     kind_n,
   )
 }
@@ -357,7 +357,7 @@ pub fn Function::removeFnAttr(self : Self, fn_attr : FnAttr) -> Unit {
 /// assert_eq(fval.countFnAttrs(), 1)
 /// ```
 pub fn Function::countFnAttrs(self : Self) -> Int {
-  @unsafe.llvm_get_attribute_count_at_index(self.getValueRef(), @uint.max_value).reinterpret_as_int()
+  @unsafe.llvm_get_attribute_count_at_index(self.getValueRef(), @uint.MAX_VALUE).reinterpret_as_int()
 }
 
 ///|

--- a/IR/IRBuilder.mbt
+++ b/IR/IRBuilder.mbt
@@ -3586,6 +3586,11 @@ pub fn IRBuilder::createPHI(
 }
 
 ///|
+fn format_type_list(types : Array[&Type]) -> String {
+  "[" + types.map(ty => ty.to_string()).join(", ") + "]"
+}
+
+///|
 /// Create a Call Instruction
 ///
 /// **Note:**
@@ -3631,8 +3636,8 @@ pub fn IRBuilder::createCall(
         (
           $| loc: \{loc}:
           #| Misuse `IRBuilder::createCall`, arguments must match function parameter types
-          $|    param_tys: \{param_tys}
-          $|    arg_tys: \{arg_tys}
+          $|    param_tys: \{format_type_list(param_tys)}
+          $|    arg_tys: \{format_type_list(arg_tys)}
         ),
       )
     }
@@ -3645,13 +3650,13 @@ pub fn IRBuilder::createCall(
         break
       }
     }
-    guard not(type_mismatch) else {
+    guard !type_mismatch else {
       raise InValidArgument(
         (
           $| loc: \{loc}:
           #| Misuse `IRBuilder::createCall`, fixed arguments must match function parameter types
-          $|    param_tys: \{param_tys}
-          $|    arg_tys: \{arg_tys}
+          $|    param_tys: \{format_type_list(param_tys)}
+          $|    arg_tys: \{format_type_list(arg_tys)}
         ),
       )
     }
@@ -3958,7 +3963,7 @@ pub fn IRBuilder::createMalloc(
   loc~ : SourceLoc,
 ) -> CallInst raise {
   guard self.positioned is Set else { raise UnsetPosition }
-  guard not(ty.tryAsAbstractType() is Some(_)) else {
+  guard !(ty.tryAsAbstractType() is Some(_)) else {
     raise ValueTypeError(
       (
         $| loc: \{loc}:

--- a/IR/Type.mbt
+++ b/IR/Type.mbt
@@ -280,7 +280,7 @@ impl Type with fn isEmptyTy(self) -> Bool {
 /// Only FunctionType, VoidType, Opaque Struct is not first class type.
 impl Type with fn isFirstClassType(self) {
   match self.asTypeEnum() {
-    StructType(sty) => not(sty.isOpaque())
+    StructType(sty) => !sty.isOpaque()
     FunctionType(_) | VoidType(_) => false
     _ => true
   }

--- a/test/binary_build_test.mbt
+++ b/test/binary_build_test.mbt
@@ -31,15 +31,13 @@ test "Binary Int Add Test" {
     #|
   inspect(fval, content=expect)
   let f32_one = ctx.getConstFloat(1.0)
-  assert_true(
-    (try? builder.createAdd(arg0, f32_one))
-    is Err(BuilderError::ValueTypeError(_)),
-  )
+  assert_builder_error(() => builder.createAdd(arg0, f32_one), err => {
+    err is BuilderError::ValueTypeError(_)
+  })
   let i64_one = ctx.getConstInt64(1)
-  assert_true(
-    (try? builder.createAdd(arg0, i64_one))
-    is Err(BuilderError::BitwidthError(_)),
-  )
+  assert_builder_error(() => builder.createAdd(arg0, i64_one), err => {
+    err is BuilderError::BitwidthError(_)
+  })
 }
 
 ///|
@@ -70,26 +68,22 @@ test "Binary Int Sub Test" {
   inspect(fval, content=expect)
   // 错误测试：类型不匹配
   let f32_one = ctx.getConstFloat(1.0)
-  assert_true(
-    (try? builder.createSub(arg0, f32_one))
-    is Err(BuilderError::ValueTypeError(_)),
-  )
+  assert_builder_error(() => builder.createSub(arg0, f32_one), err => {
+    err is BuilderError::ValueTypeError(_)
+  })
   // 错误测试：位宽不匹配
   let i64_one = ctx.getConstInt64(1)
-  assert_true(
-    (try? builder.createSub(arg0, i64_one))
-    is Err(BuilderError::BitwidthError(_)),
-  )
+  assert_builder_error(() => builder.createSub(arg0, i64_one), err => {
+    err is BuilderError::BitwidthError(_)
+  })
   // 错误测试：NSW Sub 类型不匹配
-  assert_true(
-    (try? builder.createNSWSub(f32_one, arg0))
-    is Err(BuilderError::ValueTypeError(_)),
-  )
+  assert_builder_error(() => builder.createNSWSub(f32_one, arg0), err => {
+    err is BuilderError::ValueTypeError(_)
+  })
   // 错误测试：NUW Sub 位宽不匹配
-  assert_true(
-    (try? builder.createNUWSub(arg0, i64_one))
-    is Err(BuilderError::BitwidthError(_)),
-  )
+  assert_builder_error(() => builder.createNUWSub(arg0, i64_one), err => {
+    err is BuilderError::BitwidthError(_)
+  })
 }
 
 ///|
@@ -120,26 +114,22 @@ test "Binary Int Mul Test" {
   inspect(fval, content=expect)
   // 错误测试：类型不匹配
   let f64_one = ctx.getConstDouble(1.0)
-  assert_true(
-    (try? builder.createMul(arg0, f64_one))
-    is Err(BuilderError::ValueTypeError(_)),
-  )
+  assert_builder_error(() => builder.createMul(arg0, f64_one), err => {
+    err is BuilderError::ValueTypeError(_)
+  })
   // 错误测试：位宽不匹配
   let i16_one = ctx.getConstInt16(1)
-  assert_true(
-    (try? builder.createMul(arg0, i16_one))
-    is Err(BuilderError::BitwidthError(_)),
-  )
+  assert_builder_error(() => builder.createMul(arg0, i16_one), err => {
+    err is BuilderError::BitwidthError(_)
+  })
   // 错误测试：NSW Mul 类型不匹配
-  assert_true(
-    (try? builder.createNSWMul(f64_one, arg0))
-    is Err(BuilderError::ValueTypeError(_)),
-  )
+  assert_builder_error(() => builder.createNSWMul(f64_one, arg0), err => {
+    err is BuilderError::ValueTypeError(_)
+  })
   // 错误测试：NUW Mul 位宽不匹配
-  assert_true(
-    (try? builder.createNUWMul(arg0, i16_one))
-    is Err(BuilderError::BitwidthError(_)),
-  )
+  assert_builder_error(() => builder.createNUWMul(arg0, i16_one), err => {
+    err is BuilderError::BitwidthError(_)
+  })
 }
 
 ///|
@@ -174,37 +164,31 @@ test "Binary Int Div Test" {
   inspect(fval, content=expect)
   // 错误测试：SDiv 类型不匹配
   let f32_one = ctx.getConstFloat(1.0)
-  assert_true(
-    (try? builder.createSDiv(arg0, f32_one))
-    is Err(BuilderError::ValueTypeError(_)),
-  )
+  assert_builder_error(() => builder.createSDiv(arg0, f32_one), err => {
+    err is BuilderError::ValueTypeError(_)
+  })
   // 错误测试：UDiv 位宽不匹配
   let i64_one = ctx.getConstInt64(1)
-  assert_true(
-    (try? builder.createUDiv(arg0, i64_one))
-    is Err(BuilderError::BitwidthError(_)),
-  )
+  assert_builder_error(() => builder.createUDiv(arg0, i64_one), err => {
+    err is BuilderError::BitwidthError(_)
+  })
   // 错误测试：ExactSDiv 类型不匹配
-  assert_true(
-    (try? builder.createExactSDiv(f32_one, arg0))
-    is Err(BuilderError::ValueTypeError(_)),
-  )
+  assert_builder_error(() => builder.createExactSDiv(f32_one, arg0), err => {
+    err is BuilderError::ValueTypeError(_)
+  })
   // 错误测试：ExactUDiv 位宽不匹配
   let i8_one = ctx.getConstInt8(1)
-  assert_true(
-    (try? builder.createExactUDiv(arg0, i8_one))
-    is Err(BuilderError::BitwidthError(_)),
-  )
+  assert_builder_error(() => builder.createExactUDiv(arg0, i8_one), err => {
+    err is BuilderError::BitwidthError(_)
+  })
   // 错误测试：左操作数类型不匹配
-  assert_true(
-    (try? builder.createSDiv(f32_one, arg0))
-    is Err(BuilderError::ValueTypeError(_)),
-  )
+  assert_builder_error(() => builder.createSDiv(f32_one, arg0), err => {
+    err is BuilderError::ValueTypeError(_)
+  })
   // 错误测试：右操作数类型不匹配
-  assert_true(
-    (try? builder.createUDiv(arg0, f32_one))
-    is Err(BuilderError::ValueTypeError(_)),
-  )
+  assert_builder_error(() => builder.createUDiv(arg0, f32_one), err => {
+    err is BuilderError::ValueTypeError(_)
+  })
 }
 
 ///|
@@ -234,32 +218,27 @@ test "Binary Int Rem Test" {
   inspect(fval, content=expect)
   // 错误测试：SRem 类型不匹配
   let f32_one = ctx.getConstFloat(1.0)
-  assert_true(
-    (try? builder.createSRem(arg0, f32_one))
-    is Err(BuilderError::ValueTypeError(_)),
-  )
+  assert_builder_error(() => builder.createSRem(arg0, f32_one), err => {
+    err is BuilderError::ValueTypeError(_)
+  })
   // 错误测试：URem 位宽不匹配
   let i64_one = ctx.getConstInt64(1)
-  assert_true(
-    (try? builder.createURem(arg0, i64_one))
-    is Err(BuilderError::BitwidthError(_)),
-  )
+  assert_builder_error(() => builder.createURem(arg0, i64_one), err => {
+    err is BuilderError::BitwidthError(_)
+  })
   // 错误测试：左操作数类型不匹配
-  assert_true(
-    (try? builder.createSRem(f32_one, arg0))
-    is Err(BuilderError::ValueTypeError(_)),
-  )
+  assert_builder_error(() => builder.createSRem(f32_one, arg0), err => {
+    err is BuilderError::ValueTypeError(_)
+  })
   // 错误测试：右操作数类型不匹配
-  assert_true(
-    (try? builder.createURem(arg0, f32_one))
-    is Err(BuilderError::ValueTypeError(_)),
-  )
+  assert_builder_error(() => builder.createURem(arg0, f32_one), err => {
+    err is BuilderError::ValueTypeError(_)
+  })
   // 错误测试：URem 位宽不匹配（更多情况）
   let i16_one = ctx.getConstInt16(1)
-  assert_true(
-    (try? builder.createURem(arg0, i16_one))
-    is Err(BuilderError::BitwidthError(_)),
-  )
+  assert_builder_error(() => builder.createURem(arg0, i16_one), err => {
+    err is BuilderError::BitwidthError(_)
+  })
 }
 
 ///|
@@ -295,36 +274,30 @@ test "Binary Float Test" {
   inspect(fval, content=expect)
   // 错误测试：FAdd 类型不匹配
   let i32_one = ctx.getConstInt32(1)
-  assert_true(
-    (try? builder.createFAdd(arg0, i32_one))
-    is Err(BuilderError::ValueTypeError(_)),
-  )
+  assert_builder_error(() => builder.createFAdd(arg0, i32_one), err => {
+    err is BuilderError::ValueTypeError(_)
+  })
   // 错误测试：FSub 位宽不匹配
   let f64_one = ctx.getConstDouble(1.0)
-  assert_true(
-    (try? builder.createFSub(arg0, f64_one))
-    is Err(BuilderError::BitwidthError(_)),
-  )
+  assert_builder_error(() => builder.createFSub(arg0, f64_one), err => {
+    err is BuilderError::BitwidthError(_)
+  })
   // 错误测试：FMul 类型不匹配
-  assert_true(
-    (try? builder.createFMul(i32_one, arg0))
-    is Err(BuilderError::ValueTypeError(_)),
-  )
+  assert_builder_error(() => builder.createFMul(i32_one, arg0), err => {
+    err is BuilderError::ValueTypeError(_)
+  })
   // 错误测试：FDiv 位宽不匹配
-  assert_true(
-    (try? builder.createFDiv(arg0, f64_one))
-    is Err(BuilderError::BitwidthError(_)),
-  )
+  assert_builder_error(() => builder.createFDiv(arg0, f64_one), err => {
+    err is BuilderError::BitwidthError(_)
+  })
   // 错误测试：FRem 类型不匹配
-  assert_true(
-    (try? builder.createFRem(arg0, i32_one))
-    is Err(BuilderError::ValueTypeError(_)),
-  )
+  assert_builder_error(() => builder.createFRem(arg0, i32_one), err => {
+    err is BuilderError::ValueTypeError(_)
+  })
   // 错误测试：左操作数类型不匹配
-  assert_true(
-    (try? builder.createFAdd(i32_one, arg0))
-    is Err(BuilderError::ValueTypeError(_)),
-  )
+  assert_builder_error(() => builder.createFAdd(i32_one, arg0), err => {
+    err is BuilderError::ValueTypeError(_)
+  })
 }
 
 ///|
@@ -372,26 +345,22 @@ test "Integer Compare Test" {
   inspect(fval, content=expect)
   // 错误测试：类型不匹配
   let f32_one = ctx.getConstFloat(1.0)
-  assert_true(
-    (try? builder.createICmp(EQ, arg0, f32_one))
-    is Err(BuilderError::ValueTypeError(_)),
-  )
+  assert_builder_error(() => builder.createICmp(EQ, arg0, f32_one), err => {
+    err is BuilderError::ValueTypeError(_)
+  })
   // 错误测试：位宽不匹配
   let i64_one = ctx.getConstInt64(1)
-  assert_true(
-    (try? builder.createICmp(NE, arg0, i64_one))
-    is Err(BuilderError::BitwidthError(_)),
-  )
+  assert_builder_error(() => builder.createICmp(NE, arg0, i64_one), err => {
+    err is BuilderError::BitwidthError(_)
+  })
   // 错误测试：左操作数类型不匹配
-  assert_true(
-    (try? builder.createICmp(SGT, f32_one, arg0))
-    is Err(BuilderError::ValueTypeError(_)),
-  )
+  assert_builder_error(() => builder.createICmp(SGT, f32_one, arg0), err => {
+    err is BuilderError::ValueTypeError(_)
+  })
   // 错误测试：右操作数类型不匹配
-  assert_true(
-    (try? builder.createICmp(SLT, arg0, f32_one))
-    is Err(BuilderError::ValueTypeError(_)),
-  )
+  assert_builder_error(() => builder.createICmp(SLT, arg0, f32_one), err => {
+    err is BuilderError::ValueTypeError(_)
+  })
 }
 
 ///|
@@ -445,29 +414,24 @@ test "Float Compare Test" {
   inspect(fval, content=expect)
   // 错误测试：类型不匹配
   let i32_one = ctx.getConstInt32(1)
-  assert_true(
-    (try? builder.createFCmpOEQ(arg0, i32_one))
-    is Err(BuilderError::ValueTypeError(_)),
-  )
+  assert_builder_error(() => builder.createFCmpOEQ(arg0, i32_one), err => {
+    err is BuilderError::ValueTypeError(_)
+  })
   // 错误测试：位宽不匹配
   let f64_one = ctx.getConstDouble(1.0)
-  assert_true(
-    (try? builder.createFCmpOGT(arg0, f64_one))
-    is Err(BuilderError::BitwidthError(_)),
-  )
+  assert_builder_error(() => builder.createFCmpOGT(arg0, f64_one), err => {
+    err is BuilderError::BitwidthError(_)
+  })
   // 错误测试：左操作数类型不匹配
-  assert_true(
-    (try? builder.createFCmpOGE(i32_one, arg0))
-    is Err(BuilderError::ValueTypeError(_)),
-  )
+  assert_builder_error(() => builder.createFCmpOGE(i32_one, arg0), err => {
+    err is BuilderError::ValueTypeError(_)
+  })
   // 错误测试：右操作数类型不匹配
-  assert_true(
-    (try? builder.createFCmpOLT(arg0, i32_one))
-    is Err(BuilderError::ValueTypeError(_)),
-  )
+  assert_builder_error(() => builder.createFCmpOLT(arg0, i32_one), err => {
+    err is BuilderError::ValueTypeError(_)
+  })
   // 错误测试：位宽不匹配（更多情况）
-  assert_true(
-    (try? builder.createFCmpONE(arg0, f64_one))
-    is Err(BuilderError::BitwidthError(_)),
-  )
+  assert_builder_error(() => builder.createFCmpONE(arg0, f64_one), err => {
+    err is BuilderError::BitwidthError(_)
+  })
 }

--- a/test/branch_build_test.mbt
+++ b/test/branch_build_test.mbt
@@ -76,24 +76,22 @@ test "Simple Branch Test" {
   inspect(switch_inst, content=expected_switch)
 
   // 错误测试 - createCondBr 条件必须是 i1 类型
-  assert_true(
-    (try? builder.createCondBr(switch_val, true_bb, false_bb))
-    is Err(BuilderError::ValueTypeError(_)),
+  assert_builder_error(
+    () => builder.createCondBr(switch_val, true_bb, false_bb),
+    err => err is BuilderError::ValueTypeError(_),
   )
 
   // 错误测试 - createSwitch 值必须是整数类型
   let f32_val = ctx.getConstFloat(1.0)
-  assert_true(
-    (try? builder.createSwitch(f32_val, default_bb))
-    is Err(BuilderError::ValueTypeError(_)),
-  )
+  assert_builder_error(() => builder.createSwitch(f32_val, default_bb), err => {
+    err is BuilderError::ValueTypeError(_)
+  })
 
   // 错误测试 - switch addCase 值必须是整数类型
   let another_switch = builder.createSwitch(switch_val, default_bb)
-  assert_true(
-    (try? another_switch.addCase(f32_val, case1_bb))
-    is Err(SwitchInstError::InValidSwitchCaseValue(_)),
-  )
+  assert_switch_inst_error(() => another_switch.addCase(f32_val, case1_bb), err => {
+    err is SwitchInstError::InValidSwitchCaseValue(_)
+  })
 }
 
 ///|
@@ -261,21 +259,20 @@ test "PHI Test" {
   inspect(fval, content=expect)
 
   // 错误测试 - createSelect 条件必须是 i1 类型
-  assert_true(
-    (try? builder.createSelect(true_val, true_val, false_val))
-    is Err(BuilderError::ValueTypeError(_)),
+  assert_builder_error(
+    () => builder.createSelect(true_val, true_val, false_val),
+    err => err is BuilderError::ValueTypeError(_),
   )
 
   // 错误测试 - createCondBr 条件类型错误
-  assert_true(
-    (try? builder.createCondBr(true_val, true_bb, false_bb))
-    is Err(BuilderError::ValueTypeError(_)),
+  assert_builder_error(
+    () => builder.createCondBr(true_val, true_bb, false_bb),
+    err => err is BuilderError::ValueTypeError(_),
   )
 
   // 错误测试 - createSwitch 值类型错误
   let f64_val = ctx.getConstDouble(1.0)
-  assert_true(
-    (try? builder.createSwitch(f64_val, default_bb))
-    is Err(BuilderError::ValueTypeError(_)),
-  )
+  assert_builder_error(() => builder.createSwitch(f64_val, default_bb), err => {
+    err is BuilderError::ValueTypeError(_)
+  })
 }

--- a/test/cast_build_test.mbt
+++ b/test/cast_build_test.mbt
@@ -95,70 +95,59 @@ test "Cast Test" {
   inspect(fval, content=expect)
 
   // 错误测试 - createTrunc 类型不匹配
-  assert_true(
-    (try? builder.createTrunc(f64_arg, i32_ty))
-    is Err(BuilderError::ValueTypeError(_)),
-  )
+  assert_builder_error(() => builder.createTrunc(f64_arg, i32_ty), err => {
+    err is BuilderError::ValueTypeError(_)
+  })
 
   // 错误测试 - createZExt 类型不匹配
   let f32_val = ctx.getConstFloat(1.0)
-  assert_true(
-    (try? builder.createZExt(f32_val, i32_ty))
-    is Err(BuilderError::ValueTypeError(_)),
-  )
+  assert_builder_error(() => builder.createZExt(f32_val, i32_ty), err => {
+    err is BuilderError::ValueTypeError(_)
+  })
 
   // 错误测试 - createSExt 类型不匹配
-  assert_true(
-    (try? builder.createSExt(f64_arg, i32_ty))
-    is Err(BuilderError::ValueTypeError(_)),
-  )
+  assert_builder_error(() => builder.createSExt(f64_arg, i32_ty), err => {
+    err is BuilderError::ValueTypeError(_)
+  })
 
   // 错误测试 - createFPTrunc 类型不匹配
-  assert_true(
-    (try? builder.createFPTrunc(i64_arg, f32_ty))
-    is Err(BuilderError::ValueTypeError(_)),
-  )
+  assert_builder_error(() => builder.createFPTrunc(i64_arg, f32_ty), err => {
+    err is BuilderError::ValueTypeError(_)
+  })
 
   // 错误测试 - createFPExt 类型不匹配
   let i32_val = ctx.getConstInt32(1)
-  assert_true(
-    (try? builder.createFPExt(i32_val, f64_ty))
-    is Err(BuilderError::ValueTypeError(_)),
-  )
+  assert_builder_error(() => builder.createFPExt(i32_val, f64_ty), err => {
+    err is BuilderError::ValueTypeError(_)
+  })
 
   // 错误测试 - createFPToSI 类型不匹配
-  assert_true(
-    (try? builder.createFPToSI(i64_arg, i32_ty))
-    is Err(BuilderError::ValueTypeError(_)),
-  )
+  assert_builder_error(() => builder.createFPToSI(i64_arg, i32_ty), err => {
+    err is BuilderError::ValueTypeError(_)
+  })
 
   // 错误测试 - createFPToUI 类型不匹配
-  assert_true(
-    (try? builder.createFPToUI(i32_val, i32_ty))
-    is Err(BuilderError::ValueTypeError(_)),
-  )
+  assert_builder_error(() => builder.createFPToUI(i32_val, i32_ty), err => {
+    err is BuilderError::ValueTypeError(_)
+  })
 
   // 错误测试 - createSIToFP 类型不匹配
-  assert_true(
-    (try? builder.createSIToFP(f64_arg, f32_ty))
-    is Err(BuilderError::ValueTypeError(_)),
-  )
+  assert_builder_error(() => builder.createSIToFP(f64_arg, f32_ty), err => {
+    err is BuilderError::ValueTypeError(_)
+  })
 
   // 错误测试 - createUIToFP 类型不匹配
-  assert_true(
-    (try? builder.createUIToFP(f32_val, f32_ty))
-    is Err(BuilderError::ValueTypeError(_)),
-  )
+  assert_builder_error(() => builder.createUIToFP(f32_val, f32_ty), err => {
+    err is BuilderError::ValueTypeError(_)
+  })
 
   // 错误测试 - createIntToPtr 类型不匹配
-  assert_true(
-    (try? builder.createIntToPtr(f64_arg))
-    is Err(BuilderError::ValueTypeError(_)),
-  )
+  assert_builder_error(() => builder.createIntToPtr(f64_arg), err => {
+    err is BuilderError::ValueTypeError(_)
+  })
 
   // 错误测试 - createPtrToInt 类型不匹配
-  assert_true(
-    (try? builder.createPtrToInt(i64_arg, i32_ty))
-    is Err(BuilderError::ValueTypeError(_)),
-  )
+  assert_builder_error(() => builder.createPtrToInt(i64_arg, i32_ty), err => {
+    err is BuilderError::ValueTypeError(_)
+  })
 }

--- a/test/error_helpers_test.mbt
+++ b/test/error_helpers_test.mbt
@@ -1,0 +1,23 @@
+///|
+fn[T] assert_builder_error(
+  f : () -> T raise,
+  pred : (Error) -> Bool,
+) -> Unit raise {
+  try f() catch {
+    err => assert_true(pred(err))
+  } noraise {
+    _ => fail("expected BuilderError")
+  }
+}
+
+///|
+fn[T] assert_switch_inst_error(
+  f : () -> T raise,
+  pred : (Error) -> Bool,
+) -> Unit raise {
+  try f() catch {
+    err => assert_true(pred(err))
+  } noraise {
+    _ => fail("expected SwitchInstError")
+  }
+}

--- a/test/memory_build_test.mbt
+++ b/test/memory_build_test.mbt
@@ -33,10 +33,9 @@ test "Simple Stack Memory Test" {
   inspect(fval, content=expect)
 
   // Test store with non-pointer - may not be checked in current implementation
-  assert_true(
-    (try? builder.createStore(arg0, arg0))
-    is Err(BuilderError::ValueTypeError(_)),
-  )
+  assert_builder_error(() => builder.createStore(arg0, arg0), err => {
+    err is BuilderError::ValueTypeError(_)
+  })
 }
 
 ///|
@@ -128,23 +127,21 @@ test "Aggregate Stack Memory Test" {
   inspect(fval, content=expect)
 
   // Test GEP with wrong pointer type
-  assert_true(
-    (try? builder.createGEP(val42, array_ty, [zero, one]))
-    is Err(BuilderError::ValueTypeError(_)),
-  )
+  assert_builder_error(() => builder.createGEP(val42, array_ty, [zero, one]), err => {
+    err is BuilderError::ValueTypeError(_)
+  })
 
   // Test GEP with non-integer index
   let f32_val = ctx.getConstFloat(1.0)
-  assert_true(
-    (try? builder.createGEP(array_alloca, array_ty, [zero, f32_val]))
-    is Err(BuilderError::ValueTypeError(_)),
+  assert_builder_error(
+    () => builder.createGEP(array_alloca, array_ty, [zero, f32_val]),
+    err => err is BuilderError::ValueTypeError(_),
   )
 
   // Test extractvalue with wrong index - may not be checked
-  assert_true(
-    (try? builder.createExtractValue(struct_val, 5))
-    is Err(BuilderError::InValidArgument(_)),
-  )
+  assert_builder_error(() => builder.createExtractValue(struct_val, 5), err => {
+    err is BuilderError::InValidArgument(_)
+  })
 }
 
 ///|
@@ -187,15 +184,15 @@ test "Simple Heap Memory Test" {
   inspect(fval, content=expect)
 
   // Test malloc with abstract type (should fail)
-  assert_true(
-    (try? builder.createMalloc(void_ty)) is Err(BuilderError::ValueTypeError(_)),
-  )
+  assert_builder_error(() => builder.createMalloc(void_ty), err => {
+    err is BuilderError::ValueTypeError(_)
+  })
 
   // Test free with non-pointer
   let i32_val = ctx.getConstInt32(42)
-  assert_true(
-    (try? builder.createFree(i32_val)) is Err(BuilderError::ValueTypeError(_)),
-  )
+  assert_builder_error(() => builder.createFree(i32_val), err => {
+    err is BuilderError::ValueTypeError(_)
+  })
 }
 
 ///|
@@ -320,26 +317,24 @@ test "Aggregate Heap Memory Test" {
   let i32_val = ctx.getConstInt32(42)
 
   // Test memset with wrong dst type - may not be checked
-  assert_true(
-    (try? builder.createMemSet(i32_val, byte_val, size_64, 4))
-    is Err(BuilderError::ValueTypeError(_)),
+  assert_builder_error(
+    () => builder.createMemSet(i32_val, byte_val, size_64, 4),
+    err => err is BuilderError::ValueTypeError(_),
   )
 
   // Test memcpy with wrong src type - may not be checked
-  assert_true(
-    (try? builder.createMemCpy(struct_malloc, 4, i32_val, 4, size_64))
-    is Err(BuilderError::ValueTypeError(_)),
+  assert_builder_error(
+    () => builder.createMemCpy(struct_malloc, 4, i32_val, 4, size_64),
+    err => err is BuilderError::ValueTypeError(_),
   )
 
   // Test insertvalue with wrong type - may not be checked
-  assert_true(
-    (try? builder.createInsertValue(i32_val, val100, 0))
-    is Err(BuilderError::ValueTypeError(_)),
-  )
+  assert_builder_error(() => builder.createInsertValue(i32_val, val100, 0), err => {
+    err is BuilderError::ValueTypeError(_)
+  })
 
   // Test extractvalue from non-aggregate - may not be checked
-  assert_true(
-    (try? builder.createExtractValue(i32_val, 0))
-    is Err(BuilderError::ValueTypeError(_)),
-  )
+  assert_builder_error(() => builder.createExtractValue(i32_val, 0), err => {
+    err is BuilderError::ValueTypeError(_)
+  })
 }

--- a/unsafe/BitReader.mbt
+++ b/unsafe/BitReader.mbt
@@ -29,7 +29,7 @@ extern "C" fn __llvm_parse_bitcode2(
 
 ///|
 pub fn llvm_parse_bitcode2(mem_buf : LLVMMemoryBufferRef) -> LLVMModuleRef? {
-  let out_mod : Ref[LLVMModuleRef] = Ref::new(LLVMModuleRef::null())
+  let out_mod : Ref[LLVMModuleRef] = Ref(LLVMModuleRef::null())
   let result = __llvm_parse_bitcode2(mem_buf, out_mod)
   match result {
     true => Some(out_mod.val)

--- a/unsafe/Core.mbt
+++ b/unsafe/Core.mbt
@@ -12,9 +12,9 @@ pub extern "C" fn llvm_shutdown() = "LLVMShutdown"
 
 ///|
 pub fn llvm_get_version() -> (UInt, UInt, UInt) {
-  let major = Ref::new(0U)
-  let minor = Ref::new(0U)
-  let patch = Ref::new(0U)
+  let major = Ref(0U)
+  let minor = Ref(0U)
+  let patch = Ref(0U)
   __llvm_get_version(major, minor, patch)
   (major.val, minor.val, patch.val)
 }
@@ -296,7 +296,7 @@ extern "C" fn __llvm_get_string_attribute_kind(
 
 ///|
 pub fn llvm_get_string_attribute_kind(a : LLVMAttributeRef) -> String {
-  let sz = Ref::new(0U)
+  let sz = Ref(0U)
   let cstr = __llvm_get_string_attribute_kind(a, sz)
   c_str_to_moonbit_str_with_length(cstr, sz.val)
 }
@@ -310,7 +310,7 @@ extern "C" fn __llvm_get_string_attribute_value(
 
 ///|
 pub fn llvm_get_string_attribute_value(a : LLVMAttributeRef) -> String {
-  let sz = Ref::new(0U)
+  let sz = Ref(0U)
   let cstr = __llvm_get_string_attribute_value(a, sz)
   c_str_to_moonbit_str_with_length(cstr, sz.val)
 }
@@ -529,7 +529,7 @@ extern "C" fn __llvm_get_module_identifier(
 
 ///|
 pub fn llvm_get_module_identifier(m : LLVMModuleRef) -> String {
-  let sz = Ref::new(0UL)
+  let sz = Ref(0UL)
   let cstr = __llvm_get_module_identifier(m, sz)
   c_str_to_moonbit_str_with_length(cstr, sz.val.to_uint())
 }
@@ -571,7 +571,7 @@ extern "C" fn __llvm_get_source_file_name(
 ///
 /// - see Module::getSourceFileName()
 pub fn llvm_get_source_file_name(m : LLVMModuleRef) -> String {
-  let sz = Ref::new(0UL)
+  let sz = Ref(0UL)
   let cstr = __llvm_get_source_file_name(m, sz)
   c_str_to_moonbit_str_with_length(cstr, sz.val.to_uint())
 }
@@ -882,7 +882,7 @@ extern "C" fn __llvm_get_module_inline_asm(
 /// 
 /// - see Module::getModuleInlineAsm()
 pub fn llvm_get_module_inline_asm(m : LLVMModuleRef) -> String {
-  let sz = Ref::new(0UL)
+  let sz = Ref(0UL)
   let cstr = __llvm_get_module_inline_asm(m, sz)
   c_str_to_moonbit_str_with_length(cstr, sz.val.to_uint())
 }
@@ -953,7 +953,7 @@ pub extern "C" fn llvm_get_inline_asm(
 
 ///|
 pub fn llvm_get_inline_asm_string(inline_asm_val : LLVMValueRef) -> String {
-  let sz = Ref::new(0UL)
+  let sz = Ref(0UL)
   let cstr = __llvm_get_inline_asm_asm_string(inline_asm_val, sz)
   c_str_to_moonbit_str_with_length(cstr, sz.val.to_uint())
 }
@@ -971,7 +971,7 @@ extern "C" fn __llvm_get_inline_asm_asm_string(
 pub fn llvm_get_inline_asm_constraint_string(
   inline_asm_val : LLVMValueRef,
 ) -> String {
-  let sz = Ref::new(0UL)
+  let sz = Ref(0UL)
   let cstr = __llvm_get_inline_asm_constraint_string(inline_asm_val, sz)
   c_str_to_moonbit_str_with_length(cstr, sz.val.to_uint())
 }
@@ -1196,7 +1196,7 @@ extern "C" fn __llvm_get_named_metadata_name(
 
 ///|
 pub fn llvm_get_named_metadata_name(named_md : LLVMNamedMDNodeRef) -> String {
-  let sz = Ref::new(0UL)
+  let sz = Ref(0UL)
   let cstr = __llvm_get_named_metadata_name(named_md, sz)
   c_str_to_moonbit_str_with_length(cstr, sz.val.to_uint())
 }
@@ -1333,7 +1333,7 @@ extern "C" fn __llvm_get_debug_loc_directory(
 /// - see llvm::Function::getSubprogram()
 /// 
 pub fn llvm_get_debug_loc_directory(val : LLVMValueRef) -> String {
-  let sz = Ref::new(0U)
+  let sz = Ref(0U)
   let cstr = __llvm_get_debug_loc_directory(val, sz)
   c_str_to_moonbit_str_with_length(cstr, sz.val)
 }
@@ -1349,7 +1349,7 @@ pub fn llvm_get_debug_loc_directory(val : LLVMValueRef) -> String {
 /// - see llvm::Function::getSubprogram()
 /// 
 pub fn llvm_get_debug_loc_filename(val : LLVMValueRef) -> String {
-  let sz = Ref::new(0U)
+  let sz = Ref(0U)
   let cstr = __llvm_get_debug_loc_filename(val, sz)
   c_str_to_moonbit_str_with_length(cstr, sz.val)
 }
@@ -3048,7 +3048,7 @@ pub fn LLVMValueRef::get_value_kind(self : LLVMValueRef) -> LLVMValueKind {
 /// 
 /// - see llvm::Value::getName()
 pub fn llvm_get_value_name(val : LLVMValueRef) -> String {
-  let sz = Ref::new(0UL)
+  let sz = Ref(0UL)
   let cstr = __llvm_get_value_name2(val, sz)
   c_str_to_moonbit_str_with_length(cstr, sz.val.to_uint())
 }
@@ -4743,7 +4743,7 @@ extern "C" fn __llvm_const_real_get_double(
 pub fn llvm_const_real_get_double(
   constant_val : LLVMValueRef,
 ) -> (Double, Bool) {
-  let loses_info : Ref[LLVMBool] = Ref::new(0)
+  let loses_info : Ref[LLVMBool] = Ref(0)
   let v = __llvm_const_real_get_double(constant_val, loses_info)
   (v, loses_info.val.to_moonbit_bool())
 }
@@ -4876,7 +4876,7 @@ extern "C" fn __llvm_get_as_string(
 /// 
 /// - see ConstantDataSequential::getAsString()
 pub fn llvm_get_as_string(c : LLVMValueRef) -> String {
-  let sz = Ref::new(0UL)
+  let sz = Ref(0UL)
   let cstr = __llvm_get_as_string(c, sz)
   c_str_to_moonbit_str_with_length(cstr, sz.val.to_uint())
 }
@@ -6440,7 +6440,7 @@ extern "C" fn __llvm_intrinsic_get_name(id : UInt, size : Ref[UInt64]) -> CStr =
 /// 
 /// - see llvm::Intrinsic::getName()
 pub fn llvm_intrinsic_get_name(id : UInt) -> String {
-  let sz = Ref::new(0UL)
+  let sz = Ref(0UL)
   let cstr = __llvm_intrinsic_get_name(id, sz)
   c_str_to_moonbit_str_with_length(cstr, sz.val.to_uint())
 }
@@ -7138,7 +7138,7 @@ extern "C" fn __llvm_get_md_string(v : LLVMValueRef, size : Ref[UInt]) -> CStr =
 
 ///|
 pub fn llvm_get_md_string(v : LLVMValueRef) -> String {
-  let sz = Ref::new(0U)
+  let sz = Ref(0U)
   let cstr = __llvm_get_md_string(v, sz)
   c_str_to_moonbit_str_with_length(cstr, sz.val)
 }
@@ -7316,7 +7316,7 @@ extern "C" fn __llvm_get_operand_bundle_tag(
 ///|
 /// Get the tag of an operand bundle.
 pub fn llvm_get_operand_bundle_tag(bundle : LLVMOperandBundleRef) -> String {
-  let sz = Ref::new(0UL)
+  let sz = Ref(0UL)
   let cstr = __llvm_get_operand_bundle_tag(bundle, sz)
   c_str_to_moonbit_str_with_length(cstr, sz.val.to_uint())
 }

--- a/unsafe/DebugInfo.mbt
+++ b/unsafe/DebugInfo.mbt
@@ -406,7 +406,7 @@ pub extern "C" fn llvm_di_scope_get_file(
 /// - see `DIFile::getDirectory()`
 /// 
 pub fn llvm_di_file_get_directory(file_ref : LLVMMetadataRef) -> String {
-  let len : Ref[UInt] = Ref::new(0)
+  let len : Ref[UInt] = Ref(0)
   let cstr = __llvm_di_file_get_directory(file_ref, len)
   c_str_to_moonbit_str_with_length(cstr, len.val)
 }
@@ -432,7 +432,7 @@ extern "C" fn __llvm_di_file_get_directory(
 /// 
 /// - see `DIFile::getFilename()`
 pub fn llvm_di_file_get_filename(file_ref : LLVMMetadataRef) -> String {
-  let len : Ref[UInt] = Ref::new(0)
+  let len : Ref[UInt] = Ref(0)
   let cstr = __llvm_di_file_get_filename(file_ref, len)
   c_str_to_moonbit_str_with_length(cstr, len.val)
 }
@@ -459,7 +459,7 @@ extern "C" fn __llvm_di_file_get_filename(
 /// 
 /// - see `DIFile::getSource()`
 pub fn llvm_di_file_get_source(file_ref : LLVMMetadataRef) -> String {
-  let len : Ref[UInt] = Ref::new(0)
+  let len : Ref[UInt] = Ref(0)
   let cstr = __llvm_di_file_get_source(file_ref, len)
   c_str_to_moonbit_str_with_length(cstr, len.val)
 }
@@ -1025,7 +1025,7 @@ pub extern "C" fn llvm_di_builder_create_artificial_type(
 /// 
 /// - see `DIType::getName()`
 pub fn llvm_di_type_get_name(type_ref : LLVMMetadataRef) -> String {
-  let len : Ref[UInt] = Ref::new(0)
+  let len : Ref[UInt] = Ref(0)
   let cstr = __llvm_di_type_get_name(type_ref, len)
   c_str_to_moonbit_str_with_length(cstr, len.val)
 }

--- a/unsafe/ExecutionEngine.mbt
+++ b/unsafe/ExecutionEngine.mbt
@@ -96,8 +96,8 @@ extern "C" fn __llvm_create_execution_engine_for_module(
 pub fn llvm_create_execution_engine_for_module(
   m : LLVMModuleRef,
 ) -> (LLVMExecutionEngineRef?, String) {
-  let execution_engine = Ref::new(__llvm_new_execution_engine())
-  let err_msg = Ref::new(CStr::new())
+  let execution_engine = Ref(__llvm_new_execution_engine())
+  let err_msg = Ref(CStr::new())
   let res = __llvm_create_execution_engine_for_module(
     execution_engine, m, err_msg,
   )
@@ -124,8 +124,8 @@ extern "C" fn __llvm_create_interpreter_for_module(
 pub fn llvm_create_interpreter_for_module(
   m : LLVMModuleRef,
 ) -> (LLVMExecutionEngineRef?, String) {
-  let interpreter = Ref::new(__llvm_new_execution_engine())
-  let err_msg = Ref::new(CStr::new())
+  let interpreter = Ref(__llvm_new_execution_engine())
+  let err_msg = Ref(CStr::new())
   let res = __llvm_create_interpreter_for_module(interpreter, m, err_msg)
   match res {
     true => (None, c_str_to_moonbit_str(err_msg.val))

--- a/unsafe/IRReader.mbt
+++ b/unsafe/IRReader.mbt
@@ -42,8 +42,8 @@ pub fn llvm_parse_ir_in_context(
   ctx_ref : LLVMContextRef,
   mem_buf : LLVMMemoryBufferRef,
 ) -> (LLVMModuleRef, String, LLVMBool) {
-  let cstr_ref : Ref[CStr] = Ref::new(CStr::create_null())
-  let out_m_ref : Ref[LLVMModuleRef] = Ref::new(LLVMModuleRef::null())
+  let cstr_ref : Ref[CStr] = Ref(CStr::create_null())
+  let out_m_ref : Ref[LLVMModuleRef] = Ref(LLVMModuleRef::null())
   let result = __llvm_parse_ir_in_context(ctx_ref, mem_buf, out_m_ref, cstr_ref)
   let str = cstr_ref.val.to_string()
   (out_m_ref.val, str, result)

--- a/unsafe/LLJIT.mbt
+++ b/unsafe/LLJIT.mbt
@@ -146,7 +146,7 @@ extern "C" fn llvm_new_null_orc_lljit_builder() -> LLVMOrcLLJITBuilderRef = "__l
 ///|
 pub fn llvm_orc_create_lljit() -> LLVMOrcLLJITRef {
   let builder = llvm_new_null_orc_lljit_builder()
-  let result : Ref[LLVMOrcLLJITRef] = Ref::new(llvm_new_null_orc_lljit())
+  let result : Ref[LLVMOrcLLJITRef] = Ref(llvm_new_null_orc_lljit())
   let err = __llvm_orc_create_lljit(result, builder)
   if llvm_error_is_null(err) {
     result.val
@@ -301,7 +301,7 @@ pub fn llvm_orc_lljit_lookup(
   j : LLVMOrcLLJITRef,
   name : String,
 ) -> LLVMOrcExecutorAddress? {
-  let addr : Ref[LLVMOrcExecutorAddress] = Ref::new(
+  let addr : Ref[LLVMOrcExecutorAddress] = Ref(
     LLVMOrcExecutorAddress::default(),
   )
   let err = __llvm_orc_lljit_lookup(j, addr, moonbit_str_to_c_str(name))

--- a/unsafe/utils.mbt
+++ b/unsafe/utils.mbt
@@ -138,7 +138,7 @@ pub fn LLVMTypeRef::is_null(self : LLVMTypeRef) -> Bool {
 
 ///|
 pub fn LLVMTypeRef::is_not_null(self : LLVMTypeRef) -> Bool {
-  llvm_type_is_null(self).to_moonbit_bool() |> not
+  !llvm_type_is_null(self).to_moonbit_bool()
 }
 
 ///|
@@ -157,7 +157,7 @@ pub fn LLVMValueRef::is_null(self : LLVMValueRef) -> Bool {
 
 ///|
 pub fn LLVMValueRef::is_not_null(self : LLVMValueRef) -> Bool {
-  llvm_value_ref_is_null(self) |> not
+  !llvm_value_ref_is_null(self)
 }
 
 ///|
@@ -170,7 +170,7 @@ pub fn LLVMUseRef::is_null(self : LLVMUseRef) -> Bool {
 
 ///|
 pub fn LLVMUseRef::is_not_null(self : LLVMUseRef) -> Bool {
-  llvm_use_is_null(self).to_moonbit_bool() |> not
+  !llvm_use_is_null(self).to_moonbit_bool()
 }
 
 ///|
@@ -183,7 +183,7 @@ pub fn LLVMBasicBlockRef::is_null(self : LLVMBasicBlockRef) -> Bool {
 
 ///|
 pub fn LLVMBasicBlockRef::is_not_null(self : LLVMBasicBlockRef) -> Bool {
-  llvm_bb_is_null(self) |> not
+  !llvm_bb_is_null(self)
 }
 
 ///|
@@ -196,7 +196,7 @@ pub fn LLVMAttributeRef::is_null(self : LLVMAttributeRef) -> Bool {
 
 ///|
 pub fn LLVMAttributeRef::is_not_null(self : LLVMAttributeRef) -> Bool {
-  llvm_attr_is_null(self).to_moonbit_bool() |> not
+  !llvm_attr_is_null(self).to_moonbit_bool()
 }
 
 ///|
@@ -209,7 +209,7 @@ pub fn LLVMComdatRef::is_null(self : LLVMComdatRef) -> Bool {
 
 ///|
 pub fn LLVMComdatRef::is_not_null(self : LLVMComdatRef) -> Bool {
-  llvm_comdat_is_null(self).to_moonbit_bool() |> not
+  !llvm_comdat_is_null(self).to_moonbit_bool()
 }
 
 ///|


### PR DESCRIPTION
## Summary
- Replace deprecated `not(...)`/`|> not`, `@uint.max_value`, and `Ref::new(...)` APIs.
- Avoid deprecated debug interpolation for type arrays in `IRBuilder::createCall`.
- Replace deprecated `try?` assertions in tests with shared error assertion helpers.

## Validation
- `moon check --target native --diagnostic-limit 10000` exits successfully with no `0020` warnings. Remaining diagnostics are `0027`, handled separately.
- `moon info --target native`
- `moon fmt`
- `git diff --check`
- `moon test --target native` is blocked locally: native stub compilation cannot find LLVM 19 headers. With local `llvm@18` include paths forced, compilation reaches LLVM 19-only enum values (`LLVMAtomicRMWBinOpUIncWrap`/`LLVMAtomicRMWBinOpUDecWrap`) and fails because this machine only has LLVM 18 installed.
